### PR TITLE
Add an 'explode' tag as an extension.

### DIFF
--- a/ext/explode.php
+++ b/ext/explode.php
@@ -1,0 +1,35 @@
+<?php
+
+class Explode_Tag extends H2o_Node
+{
+    public $position;
+    private $variable;
+    private $seperator;
+    private $shortcut;
+    private $nodelist;
+    private $syntax = '/^(?P<var>[\w]+(:?\.[\w\d]+)*)\s+on\s+(?P<sepquote>[\'"])(?P<separator>(?!.*\k<sepquote>.*\k<sepquote>).*)\k<sepquote>\s+as\s+(?P<short>[\w]+(:?\.[\w\d]+)?)$/';
+
+    function __construct($argstring, $parser, $pos = 0)
+    {
+        if (!preg_match($this->syntax, $argstring, $matches)) {
+            throw new TemplateSyntaxError('Invalid explode tag syntax');
+        }
+
+        # extract the long name, separator, and shortcut
+        $this->variable = $matches['var'];
+        $this->seperator = $matches['separator'];
+        $this->shortcut = $matches['short'];
+        $this->nodelist = $parser->parse('endexplode');
+    }
+
+    function render($context, $stream)
+    {
+        $variable = $context->getVariable($this->variable);
+        $exploded = explode($this->seperator, $variable);
+        $context->push([$this->shortcut => $exploded]);
+        $this->nodelist->render($context, $stream);
+        $context->pop();
+    }
+}
+
+H2o::addTag('explode');


### PR DESCRIPTION
This is an extension we've added to our deployment.

The syntax is very similar to the 'with' tag. This keeps `variable_parts` within the block.
```
{% explode [variable] on '[separator]' as [variable_parts] %}
{% endexplode %}
```

We're using this in our welcome emails to provide control panel details.
```
{% load explode %}
{% for option in service.options %}
    {% if option.option_name == 'control_panel_license' %}
        {% explode option.option_value on '_' as value_parts %}
            {% if value_parts.first == 'cpanel' %}
To access cPanel WHM go to ...
            {% endif %}
            {% if value_parts.first == 'directadmin' %}
To access Directadmin go to ...
            {% endif %}
        {% endexplode %}
    {% endif %}
{% endfor %}
```

This is another change needed because of cPanel having multiple licenses, but there's not currently a way to check part of a string. This seemed like an easier option that might have other uses in the future.